### PR TITLE
refactor

### DIFF
--- a/src/eclingo/parsing/transformers/function_transformer.py
+++ b/src/eclingo/parsing/transformers/function_transformer.py
@@ -1,29 +1,42 @@
 """Module providing an AST function Trasnformer"""
 import clingo
 from clingo import ast
-from clingo.ast import Transformer
+from clingo.ast import AST, Transformer
 
 
-def rule_to_symbolic_term_adapter(rules):
-    """Helper function"""
-    rule_trans = _SymbolicTermToFunctionTransformer()
-    rule = rule_trans.visit_sequence(rules)
-    return rule
+def rule_to_symbolic_term_adapter(x: AST):
+    """
+    Replaces all occurrences of objects of the class clingo.Function in x
+    by the corresponding object of the class ast.Function. It takes care of
+    ajust the ast removing the SymbolicTerm object if necessary.
+    """
+    return _SymbolicTermToFunctionTransformer().visit(x)
 
 
 class _SymbolicTermToFunctionTransformer(Transformer):
     """Transforms a SymbolicTerm AST into a Function AST"""
 
-    def visit_SymbolicTerm(self, term):  # pylint: disable=invalid-name
-        """Visit AST to find SymbolicTerm"""
+    def visit_SymbolicTerm(self, term: AST):  # pylint: disable=invalid-name
+        """
+        Transform the given symbolic term.
 
-        if term.symbol.type != clingo.SymbolType.Function:
+        Parameters
+        ----------
+        x
+            The AST to rewrite.
+
+        Returns
+        -------
+        The rewritten AST.
+        """
+
+        symbol = term.symbol
+
+        if symbol.type != clingo.SymbolType.Function:
             return term
 
         location = term.location
-        symbol = term.symbol
         name = symbol.name
         arguments = symbol.arguments
 
-        function = ast.Function(location, name, arguments, False)
-        return function
+        return ast.Function(location, name, arguments, False)


### PR DESCRIPTION
In ```clingox``` functions usually apply to AST instead of sequences of ASTs. I modified the function to apply to an AST and now tests fails. 

In general, it should work by replacing
```python
 function_transformer.rule_to_symbolic_term_adapter(some_list)
```
by
```python
[function_transformer.rule_to_symbolic_term_adapter(stm) for stm in some_list]
```
Can you look into this? Then merge into your branch.