### PR TITLE
Fixing parameters control.add() & control.ground()

### DIFF
--- a/src/eclingo/solver/tester.py
+++ b/src/eclingo/solver/tester.py
@@ -141,8 +141,8 @@ class CandidateTesterReification:
         with SymbolicBackend(self.control.backend()) as backend:
             for symbol in self.reified_program:
                 backend.add_rule([symbol])
-        self.control.add(program_meta_encoding)
-        self.control.ground()
+        self.control.add("base", [], program_meta_encoding)
+        self.control.ground([("base", [])])
         self.initialized_control = True
         self.grounding_time += time.time() - start_time
 


### PR DESCRIPTION
I found a bug within reification2. 

Let's say we execute the following command:

echo "b :- &k{ not a }. c :- &k{ b }. {a}." | eclingo 

It will throw an error because the functions control.add() and control.ground() need a set of parameters.

I have made those changes in lute/reif2_wip.

Please review them.